### PR TITLE
Check if the group limit exists

### DIFF
--- a/src/Grammars/CompilesGroupLimit.php
+++ b/src/Grammars/CompilesGroupLimit.php
@@ -14,7 +14,7 @@ trait CompilesGroupLimit
      */
     public function compileSelect(Builder $query)
     {
-        if ($query->groupLimit) {
+        if (isset($query->groupLimit)) {
             if (is_null($query->columns)) {
                 $query->columns = ['*'];
             }


### PR DESCRIPTION
We need to check whether `groupLimit` exists in the query using `isset` because if the target model doesn't have `HasEagerLimit` attached, it'll show an error message:

> Undefined property: Illuminate\Database\Query\Builder::$groupLimit

## Steps to reproduce

### User Model

```php
use Thirdparty\Package\HasRoles;
use Illuminate\Database\Eloquent\Model;
use Staudenmeir\EloquentEagerLimit\HasEagerLimit;

class User extends Model
{
    use HasEagerLimit, HasRoles;
}
```

### HasRoles Trait (third party package)

```php
trait HasRoles
{
    public function roles()
    {
        return $this->belongsToMany(Role::class);
    }
}
```

The following query will show this error message:

```php
User::has('roles')->get();
```