### PR TITLE
Fix MySqlGrammar when using multiple databases

### DIFF
--- a/src/Grammars/MySqlGrammar.php
+++ b/src/Grammars/MySqlGrammar.php
@@ -59,7 +59,7 @@ class MySqlGrammar extends Base
             $query->offset = null;
         }
 
-        $column = Str::after($query->groupLimit['column'], '.');
+        $column = explode('.', $query->groupLimit['column'])[substr_count($query->groupLimit['column'], '.')];
 
         $column = $this->wrap($column);
 
@@ -86,7 +86,6 @@ class MySqlGrammar extends Base
         }
 
         return $sql.' order by laravel_row';
-
 
     }
 }


### PR DESCRIPTION
This packages works great with a single database. But when used with multiple database the column parameter gets prepend with the selected database like: '`database`.`table`.`column`'. The current implementation uses str::after which removes the table prepend when using a single database, when you use multiple database it only removes the database prepend and you are left with: '`table`.`column`' which will result in an query error: 'Column not found: 1054 Unknown column 'table.column' in 'field list''.  

This PR will fix the MySqlGrammar for multiple database setups. It simply splits the column string on the dots and sets the column parameter to the last element of the resulted split array. Which will always contain the column name. 