### PR TITLE
Bug fix: order bindings are select bindings

### DIFF
--- a/src/Grammars/CompilesGroupLimit.php
+++ b/src/Grammars/CompilesGroupLimit.php
@@ -33,7 +33,9 @@ trait CompilesGroupLimit
      */
     protected function compileGroupLimit(Builder $query)
     {
-        $query->setBindings($query->getRawBindings()['order'], 'select');
+        $selectBindings = array_merge($query->getRawBindings()['select'], $query->getRawBindings()['order']);
+
+        $query->setBindings($selectBindings, 'select');
         $query->setBindings([], 'order');
 
         $limit = (int) $query->groupLimit['value'];

--- a/src/Grammars/CompilesGroupLimit.php
+++ b/src/Grammars/CompilesGroupLimit.php
@@ -33,6 +33,9 @@ trait CompilesGroupLimit
      */
     protected function compileGroupLimit(Builder $query)
     {
+        $query->setBindings($query->getRawBindings()['order'], 'select');
+        $query->setBindings([], 'order');
+
         $limit = (int) $query->groupLimit['value'];
 
         $offset = $query->offset;


### PR DESCRIPTION
If a query has order bindings, then those order bindings should be moved to the select bindings. That's because the group limit moves everything related to ordering inside the select-query (except in the case of MySQL 5.7.9). Without this change, the bindings are incorrectly used.