### PR TITLE
Laravel 9.0 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         php: [8.1, 8.0]
         database: [mysql, pgsql, sqlite, sqlsrv]
-        release: [stable, lowest]
+        release: [stable] # Temporarily remove lowest
         include:
           - php: 8.0
             release: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,7 @@ jobs:
           MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
           PGSQL_PORT: ${{ job.services.pgsql.ports[5432] }}
           SQLSRV_PORT: ${{ job.services.sqlsrv.ports[1433] }}
-      - run: vendor/bin/ocular code-coverage:upload --format=php-clover coverage.xml
+      - run: |
+          composer global require scrutinizer/ocular
+          ocular code-coverage:upload --format=php-clover coverage.xml
         if: matrix.coverage == 'xdebug'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.0, 7.4, 7.3]
+        php: [8.1, 8.0]
         database: [mysql, pgsql, sqlite, sqlsrv]
         release: [stable, lowest]
         include:

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     },
     "require-dev": {
         "laravel/homestead": "^11.0|^12.0",
-        "phpunit/phpunit": "^9.5",
-        "scrutinizer/ocular": "^1.8"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "illuminate/database": "^9.0"
     },
     "require-dev": {
-        "laravel/homestead": "^11.0|^12.0",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "illuminate/database": "^8.0"
+        "php": "^8.0",
+        "illuminate/database": "^9.0"
     },
     "require-dev": {
         "laravel/homestead": "^11.0|^12.0",
-        "phpunit/phpunit": "^9.3",
+        "phpunit/phpunit": "^9.5",
         "scrutinizer/ocular": "^1.8"
     },
     "autoload": {


### PR DESCRIPTION
Laravel 9.0 is not released yet, so it is intended to create new unstable branch instead of merging to master.