### PR TITLE
[1.6.1] Add support for "distinct" select queries

### DIFF
--- a/tests/BelongsToManyTest.php
+++ b/tests/BelongsToManyTest.php
@@ -38,4 +38,12 @@ class BelongsToManyTest extends TestCase
         $this->assertEquals([6, 5], $users[1]->roles->pluck('id')->all());
         $this->assertArrayNotHasKey('@laravel_partition := `pivot_user_id`', $users[0]->roles[0]);
     }
+
+    public function testDistinct()
+    {
+        $users = User::with('cities')->get();
+
+        $this->assertEquals(2, $users[0]->cities->count());
+        $this->assertEquals(1, $users[1]->cities->count());
+    }
 }

--- a/tests/Models/City.php
+++ b/tests/Models/City.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Tests\Models;
+
+class City extends Model
+{
+}

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -6,6 +6,11 @@ class User extends Model
 {
     public $timestamps = false;
 
+    public function cities()
+    {
+        return $this->belongsToMany(City::class, 'user_cities')->limit(2)->distinct();
+    }
+
     public function post()
     {
         return $this->hasOne(Post::class)->latest()->limit(1);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use PHPUnit\Framework\TestCase as Base;
+use Tests\Models\City;
 use Tests\Models\Comment;
 use Tests\Models\Country;
 use Tests\Models\Post;
@@ -46,9 +47,20 @@ abstract class TestCase extends Base
             $table->timestamps();
         });
 
+        DB::schema()->create('cities', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
         DB::schema()->create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('country_id');
+        });
+
+        DB::schema()->create('user_cities', function (Blueprint $table) {
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('city_id');
+            $table->enum('association', ['residence', 'birthplace']);
         });
 
         DB::schema()->create('posts', function (Blueprint $table) {
@@ -96,8 +108,18 @@ abstract class TestCase extends Base
         Country::create();
         Country::create();
 
+        City::create();
+        City::create();
+
         User::create(['country_id' => 1]);
         User::create(['country_id' => 2]);
+
+        DB::table('user_cities')->insert([
+            ['user_id' => 1, 'city_id' => 1, 'association' => 'birthplace'],
+            ['user_id' => 1, 'city_id' => 2, 'association' => 'residence'],
+            ['user_id' => 2, 'city_id' => 1, 'association' => 'birthplace'],
+            ['user_id' => 2, 'city_id' => 1, 'association' => 'residence'],
+        ]);
 
         Post::create(['user_id' => 1, 'created_at' => new Carbon('2018-01-01 00:00:01')]);
         Post::create(['user_id' => 1, 'created_at' => new Carbon('2018-01-01 00:00:02')]);


### PR DESCRIPTION
`$query->distinct()` appears to be broken when using eager-limit.

For example a `BelongsToMany` relation may return multiple of the same related models, if there are multiple pivot rows in the intermediate table. Normally, this can be avoided by using `$query->distinct()`, however it appears this doesn't work when combined with `$query->limit()`.

This PR includes tests that illustrate the issue: `User` is related to `City` via a `BelongsToMany` relationship defined in the intermediate table `user_cities`. The intermediate table has the columns (`user_id`, `city_id`, `association`) where `association` may be "birthplace" or "residence". A user can be related to the same city via multiple intermediate rows, i.e. if a city is both its birthplace and residence. Adding the `$query->distinct()` modifier should filter duplicated related models, but this doesn't work when combined with eager-limit.