### PR TITLE
Handle `mariadb` driver name

### DIFF
--- a/src/HasEagerLimit.php
+++ b/src/HasEagerLimit.php
@@ -44,6 +44,7 @@ trait HasEagerLimit
 
         switch ($driver) {
             case 'mysql':
+            case 'mariadb':                
                 return new MySqlGrammar();
             case 'pgsql':
                 return new PostgresGrammar();


### PR DESCRIPTION
With https://github.com/ybr-nx/laravel-mariadb, the driver name  in `config/database.php` is `mariadb`.